### PR TITLE
doc: add `re` modifier description

### DIFF
--- a/docs/basics/modifiers.md
+++ b/docs/basics/modifiers.md
@@ -343,7 +343,7 @@ detection:
 ```
 
 ```splunk [Splunk Output]
-regex fieldname=".*needle$"
+* | regex fieldname=".*needle$"
 ```
 
 :::

--- a/docs/basics/modifiers.md
+++ b/docs/basics/modifiers.md
@@ -41,6 +41,7 @@ Below is a list of available field modifiers.
     <li><a href="#gte"><code>gte</code></a></li>
     <li><a href="#lt"><code>lt</code></a></li>
     <li><a href="#lte"><code>lte</code></a></li>
+    <li><a href="#re"><code>re</code></a></li>
     <li><a href="#startswith"><code>startswith</code></a></li>
     <li><a href="#wide"><code>utf16</code> / <code>utf16le</code> / <code>utf16be</code> / <code>wide</code></a></li>
     <li><a href="#windash"><code>windash</code></a></li>
@@ -328,6 +329,26 @@ fieldname<=15
 :::
 
 The `lte` modifier will provide a search where the value of `fieldname` is less than or equal to the value provided.
+
+---
+
+### re
+
+::: code-group
+
+```yaml [/rules/needle_in_end_of_haystack.yaml]
+detection:
+    selection:
+        fieldname|re: .*needle$
+```
+
+```splunk [Splunk Output]
+regex fieldname=".*needle$"
+```
+
+:::
+
+The `re` modifier will provide a search where the value of `fieldname` matches the provided regex.
 
 ---
 


### PR DESCRIPTION
Thank you so much for creating great website :)
I think the `re` modifier is currently supported, but it wasn't mentioned on the website so I added it as follows.

<img width="1440" alt="スクリーンショット 2023-12-29 22 59 44" src="https://github.com/SigmaHQ/sigmahq.github.io/assets/41001169/03d2186e-2f71-4788-940c-3eb1ec2628cf">

(If the `re` modifier is not included intentionally, I will close this PR.)

Regards,