### PR TITLE
Added Discord Link

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -258,6 +258,7 @@ export default defineConfig({
             text: 'Edit on GitHub'
         },
         socialLinks: [
+            {icon: 'discord', link: 'https://discord.gg/kQQBn5W2z5'},
             {icon: 'twitter', link: 'https://twitter.com/Sigma_HQ/'},
             {icon: 'github', link: 'https://github.com/SigmaHQ/sigma'},
         ],

--- a/.vitepress/theme/layouts/Docsv2.vue
+++ b/.vitepress/theme/layouts/Docsv2.vue
@@ -69,6 +69,8 @@ function active_link(link: string) {
                   <a href="https://github.com/SigmaHQ/" class="hover:text-cyan-600" target="_blank">Github</a>
                   <span class="opacity-30">|</span>
                   <a href="https://twitter.com/Sigma_HQ/" class="hover:text-cyan-600" target="_blank">X.com</a>
+                  <span class="opacity-30">|</span>
+                  <a href="https://discord.gg/kQQBn5W2z5" class="hover:text-cyan-600" target="_blank">Discord</a>
                 </div>
             </div>
         </template>


### PR DESCRIPTION
This PR adds a discord invite link to the SigmaHQ website, both in the header and in the footer.