### PR TITLE
Fixes a link on `contributing` page

### DIFF
--- a/docs/digging-deeper/contributing.md
+++ b/docs/digging-deeper/contributing.md
@@ -41,6 +41,6 @@ For each logsource, SigmaHQ enforces a naming scheme for how rule files are to b
 <ChecklistItem :number="3" heading="You're ready to open up a PR for your rule." class="">
 <template #text class="">
 If you've finished writing your Sigma rule, and it adheres to points #1 and #2, you're ready to open up a Pull Request under the SigmaHQ repository.
-<button class="block w-full p-2 bg-green-400/30 outline outline-1 outline-green-400/50 !text-white rounded-lg mt-4 text-center">Open a new PR on SigmaHQ <ChevronRightIcon class="w-4 h-4 inline-block" /></button>
+<a href="https://github.com/SigmaHQ/sigma/pulls" class="block w-full p-2 bg-green-400/30 outline outline-1 outline-green-400/50 !text-white rounded-lg mt-4 text-center">Open a new PR on SigmaHQ <ChevronRightIcon class="w-4 h-4 inline-block" /></a>
 </template>
 </ChecklistItem>


### PR DESCRIPTION
This pull request makes a small but helpful change to the contributing.md file in the docs/digging-deeper directory.
The change is to the button/link at the end of the document which encourages users to open a new PR on the SigmaHQ repository after writing a Sigma rule.

Previously, clicking this button would not take the user anywhere. The HTML has been updated from a <button> element to an <a> link that points directly to https://github.com/SigmaHQ/sigma/pulls, which is the Pull Requests page for the main SigmaHQ/sigma repo.