### PR TITLE
Small typo in CVE tag example

### DIFF
--- a/docs/basics/rules.md
+++ b/docs/basics/rules.md
@@ -550,7 +550,7 @@ tags:
 
   # CVE
   - cve.2022.27925 # OR
-  - cve-2022-27925
+  - cve.2022-27925
 ```
 
 ::: tip Tags Naming Convention

--- a/docs/basics/rules.md
+++ b/docs/basics/rules.md
@@ -549,7 +549,6 @@ tags:
   - tlp.green
 
   # CVE
-  - cve.2022.27925 # OR
   - cve.2022-27925
 ```
 


### PR DESCRIPTION
Should be `cve.2022-2795` and not `cve-2022-2795` according to the Sigma specification appendix (https://github.com/SigmaHQ/sigma-specification/blob/main/appendix/sigma-tags-appendix.md#namespace-cve)