### PR TITLE
fix: fix cased typo

### DIFF
--- a/docs/basics/modifiers.md
+++ b/docs/basics/modifiers.md
@@ -135,7 +135,7 @@ The `base64offset` modifier is usually preferred over the `base64` modifier, bec
 ```yaml [/rules/needle_in_end_of_haystack.yaml]
 detection:
   selection:
-    fieldname|case: "CaseSensitiveValue"
+    fieldname|cased: "CaseSensitiveValue"
   condition: selection
 ```
 


### PR DESCRIPTION
Hello, I looked into [this section](https://sigmahq.io/docs/basics/modifiers.html#cased) and I think there is a typo. 
This modifier should be `cased` not `case`.

