### PR TITLE
Updated(getting-started.md): how to check Sigma version after installation

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -46,7 +46,7 @@ If you don't want to use `pip`, or if you instead want to download and install `
 git clone https://github.com/SigmaHQ/sigma-cli.git
 cd sigma-cli
 poetry install && poetry shell
-sigma --version
+sigma version
 ```
 
 ## Install your SIEM plugin <div class="inline-block -mt-3"><Badge  type="tip" text="New" /></div>


### PR DESCRIPTION
Hey team,

Just adding a small change to the getting-started.md file.
I've just installed Sigma on my workspace and noticed that the check version command is slightly incorrect.

![image](https://github.com/user-attachments/assets/9b754c27-4da0-4b35-b9c9-0acd1868dffc)
